### PR TITLE
Remove obsolete Cloud VPS password reset instructions

### DIFF
--- a/pages/02.managed-vps/04.plesk/03.how-to-reset-plesk-admin-password/docs.en.md
+++ b/pages/02.managed-vps/04.plesk/03.how-to-reset-plesk-admin-password/docs.en.md
@@ -5,20 +5,20 @@ taxonomy:
         - docs
 aura:
     pagetype: website
-    description: 'Here are the four simple steps you need to preform in order to reset Plesk admin password in your Layershift Control Panel.'
+    description: 'Here are the four simple steps you need to preform in order to reset Plesk admin password in your Layershift Dashboard.'
 metadata:
-    description: 'Here are the four simple steps you need to preform in order to reset Plesk admin password in your Layershift Control Panel.'
+    description: 'Here are the four simple steps you need to preform in order to reset Plesk admin password in your Layershift Dashboard.'
     'og:url': 'https://www.layershift.com/kb/managed-vps/plesk/how-to-reset-plesk-admin-password'
     'og:type': website
     'og:title': 'How to reset Plesk admin password | Layershift KB'
-    'og:description': 'Here are the four simple steps you need to preform in order to reset Plesk admin password in your Layershift Control Panel.'
+    'og:description': 'Here are the four simple steps you need to preform in order to reset Plesk admin password in your Layershift Dashboard.'
     'og:image': 'https://www.layershift.com/kb/kb/user/images/ls-kb.jpg'
     'og:image:type': image/jpeg
     'og:image:width': 1200
     'og:image:height': 630
     'og:author': Layershift
     'article:published_time': '2024-06-21T12:24:53+01:00'
-    'article:modified_time': '2024-06-21T12:24:53+01:00'
+    'article:modified_time': '2026-05-07T13:20:53+01:00'
     'article:author': Layershift
 menu: 'Reset admin password'
 media_order: 'How to reset Plesk admin password-1.png,How to reset Plesk admin password-2.png,How to reset Plesk admin password-3.png,How to reset Plesk admin password-auth_layershift_com.png,How to reset Plesk admin password-dashboard_layershift_com.png,How to reset Plesk admin password-dashboard_layershift_com-servers.png,How to reset Plesk admin password-dashboard_layershift_com-servers-reset_password.png,How to reset Plesk admin password-dashboard_layershift_com-servers-reset_password-complete.png'
@@ -37,24 +37,3 @@ It’s possible to reset the password for your Managed VPS Plesk control panel a
 ![How%20to%20reset%20Plesk%20admin%20password-dashboard_layershift_com-servers-reset_password](How%20to%20reset%20Plesk%20admin%20password-dashboard_layershift_com-servers-reset_password.png "How%20to%20reset%20Plesk%20admin%20password-dashboard_layershift_com-servers-reset_password")
 * Copy the new password and click on the Login button
 ![How%20to%20reset%20Plesk%20admin%20password-dashboard_layershift_com-servers-reset_password-complete](How%20to%20reset%20Plesk%20admin%20password-dashboard_layershift_com-servers-reset_password-complete.png "How%20to%20reset%20Plesk%20admin%20password-dashboard_layershift_com-servers-reset_password-complete")
- 
-
-
-#Cloud VPS
-It’s possible to reset the password for your Cloud VPS Plesk control panel at anytime via your Layershift account at [control.layershift.com](https://control.layershift.com/) .
-
-* Make sure your correct subscription is selected in the top right-hand drop-down menu.
-
-![How%20to%20reset%20Plesk%20admin%20password-1](How%20to%20reset%20Plesk%20admin%20password-1.png "How%20to%20reset%20Plesk%20admin%20password-1")
-
-* Go to the `Home` tab:
-
-![How%20to%20reset%20Plesk%20admin%20password-2](How%20to%20reset%20Plesk%20admin%20password-2.png "How%20to%20reset%20Plesk%20admin%20password-2")
-
-* Next, browse to the `System` tab and click on the icon for `Parallels Plesk Panel` to enter the information page for your Plesk Control Panel.
-
-![How%20to%20reset%20Plesk%20admin%20password-3](How%20to%20reset%20Plesk%20admin%20password-3.png "How%20to%20reset%20Plesk%20admin%20password-3")
-
-* Once the page has loaded you’ll need to click the button `Reset Password`  and the system will automatically generate a new password for the administrator account. The password will be emailed to both the technical and administrator contact email addresses. You will then be able to login to your Plesk Control Panel with the login name ‘admin’ and your newly generated password.
-
-!!! NOTE: We strongly recommend that you change your password to something secure once logged in as the password was sent in plain text via email.


### PR DESCRIPTION
Cloud VPS instructions are not relevant anymore, so they should be removed.